### PR TITLE
Refactor endpoints and add vehicle photo management functionality

### DIFF
--- a/src/main/java/nl/novi/sd/carrental/controller/ReservationController.java
+++ b/src/main/java/nl/novi/sd/carrental/controller/ReservationController.java
@@ -20,8 +20,8 @@ public class ReservationController {
     private final ModelMapper mapper = new ModelMapper();
 
     @ResponseBody
-    @GetMapping
-    public List<ReservationDto> getReservationsByUserId(@RequestParam Long userId) {
+    @GetMapping("/users/{userId}")
+    public List<ReservationDto> getReservationsByUserId(@PathVariable Long userId) {
         return reservationService
                 .getReservationsByUserId(userId)
                 .stream()
@@ -30,8 +30,8 @@ public class ReservationController {
     }
 
     @ResponseBody
-    @GetMapping
-    public List<ReservationDto> getActiveReservationsByUserId(@RequestParam Long userId) {
+    @GetMapping("/users/{userId}/active")
+    public List<ReservationDto> getActiveReservationsByUserId(@PathVariable Long userId) {
         return reservationService
                 .getActiveReservationsByUserId(userId)
                 .stream()

--- a/src/main/java/nl/novi/sd/carrental/dto/VehicleDto.java
+++ b/src/main/java/nl/novi/sd/carrental/dto/VehicleDto.java
@@ -14,4 +14,5 @@ public class VehicleDto {
     private Double pricePerDay;
     private Long parkingSpaceId;
     private List<ReservationDto> reservations;
+    private Long photoId;
 }

--- a/src/main/java/nl/novi/sd/carrental/dto/VehiclePhotoDto.java
+++ b/src/main/java/nl/novi/sd/carrental/dto/VehiclePhotoDto.java
@@ -1,0 +1,10 @@
+package nl.novi.sd.carrental.dto;
+
+public class VehiclePhotoDto {
+    private Long id;
+    private String url;
+    private String originalFileName;
+    private String contentType;
+    private byte[] contents;
+    private Long vehicleId;
+}

--- a/src/main/java/nl/novi/sd/carrental/model/Vehicle.java
+++ b/src/main/java/nl/novi/sd/carrental/model/Vehicle.java
@@ -28,4 +28,8 @@ public class Vehicle {
 
     @OneToMany(mappedBy = "vehicle", cascade = CascadeType.ALL)
     private List<Reservation> reservations;
+
+    @OneToOne
+    @JoinColumn(name = "vehicle_photo_id")
+    private VehiclePhoto vehiclePhoto;
 }

--- a/src/main/java/nl/novi/sd/carrental/model/VehiclePhoto.java
+++ b/src/main/java/nl/novi/sd/carrental/model/VehiclePhoto.java
@@ -1,0 +1,21 @@
+package nl.novi.sd.carrental.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+public class VehiclePhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String url;
+    private String originalFileName;
+    private String contentType;
+
+    @Lob
+    private byte[] contents;
+
+    @OneToOne
+    private Vehicle vehicle;
+}

--- a/src/main/java/nl/novi/sd/carrental/repository/VehiclePhotoRepository.java
+++ b/src/main/java/nl/novi/sd/carrental/repository/VehiclePhotoRepository.java
@@ -1,0 +1,7 @@
+package nl.novi.sd.carrental.repository;
+
+import nl.novi.sd.carrental.model.VehiclePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehiclePhotoRepository extends JpaRepository<VehiclePhoto, Long> {
+}

--- a/src/main/java/nl/novi/sd/carrental/service/VehiclePhotoService.java
+++ b/src/main/java/nl/novi/sd/carrental/service/VehiclePhotoService.java
@@ -1,0 +1,13 @@
+package nl.novi.sd.carrental.service;
+
+import nl.novi.sd.carrental.model.VehiclePhoto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface VehiclePhotoService {
+
+    VehiclePhoto storePhoto(MultipartFile file, String url) throws IOException;
+
+    VehiclePhoto getPhotoById(Long id);
+}

--- a/src/main/java/nl/novi/sd/carrental/service/VehiclePhotoServiceImpl.java
+++ b/src/main/java/nl/novi/sd/carrental/service/VehiclePhotoServiceImpl.java
@@ -1,0 +1,36 @@
+package nl.novi.sd.carrental.service;
+
+import lombok.RequiredArgsConstructor;
+import nl.novi.sd.carrental.exception.ResourceNotFoundException;
+import nl.novi.sd.carrental.model.VehiclePhoto;
+import nl.novi.sd.carrental.repository.VehiclePhotoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Service
+public class VehiclePhotoServiceImpl implements VehiclePhotoService {
+
+    private final VehiclePhotoRepository vehiclePhotoRepository;
+
+
+    @Override
+    public VehiclePhoto storePhoto(MultipartFile file, String url) throws IOException {
+        VehiclePhoto photo = new VehiclePhoto();
+
+        photo.setOriginalFileName(file.getOriginalFilename());
+        photo.setUrl(url);
+        photo.setContentType(file.getContentType());
+        photo.setContents(file.getBytes());
+
+        return vehiclePhotoRepository.save(photo);
+    }
+
+    @Override
+    public VehiclePhoto getPhotoById(Long id) {
+        return vehiclePhotoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("photo not found"));
+    }
+}

--- a/src/main/java/nl/novi/sd/carrental/service/VehicleService.java
+++ b/src/main/java/nl/novi/sd/carrental/service/VehicleService.java
@@ -1,6 +1,7 @@
 package nl.novi.sd.carrental.service;
 
 import nl.novi.sd.carrental.model.Vehicle;
+import nl.novi.sd.carrental.model.VehiclePhoto;
 
 import java.util.List;
 
@@ -14,4 +15,8 @@ public interface VehicleService {
     Vehicle updateVehicle(Long id, Vehicle vehicle);
 
     void deleteVehicle(Long id);
+
+    Vehicle addPhotoToVehicle(Long vehicleId, VehiclePhoto photo);
+
+    VehiclePhoto getPhotoFromVehicle(Long vehicleId);
 }

--- a/src/main/java/nl/novi/sd/carrental/service/VehicleServiceImpl.java
+++ b/src/main/java/nl/novi/sd/carrental/service/VehicleServiceImpl.java
@@ -1,8 +1,10 @@
 package nl.novi.sd.carrental.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import nl.novi.sd.carrental.exception.ResourceNotFoundException;
 import nl.novi.sd.carrental.model.Vehicle;
+import nl.novi.sd.carrental.model.VehiclePhoto;
 import nl.novi.sd.carrental.repository.VehicleRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +14,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VehicleServiceImpl implements VehicleService {
 
+    public static final String VEHICLE_NOT_FOUND_MESSAGE = "Vehicle not found";
     private final VehicleRepository VehicleRepository;
+    private final VehicleRepository vehicleRepository;
 
     @Override
     public Vehicle createVehicle(Vehicle vehicle) {
@@ -22,7 +26,7 @@ public class VehicleServiceImpl implements VehicleService {
     @Override
     public Vehicle getVehicle(Long id) {
         return VehicleRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Vehicle not found"));
+                .orElseThrow(() -> new ResourceNotFoundException(VEHICLE_NOT_FOUND_MESSAGE));
     }
 
     @Override
@@ -33,7 +37,7 @@ public class VehicleServiceImpl implements VehicleService {
     @Override
     public Vehicle updateVehicle(Long vehicleId, Vehicle updatedVehicle) {
         Vehicle existingVehicle = VehicleRepository.findById(vehicleId)
-                .orElseThrow(() -> new ResourceNotFoundException("Vehicle not found"));
+                .orElseThrow(() -> new ResourceNotFoundException(VEHICLE_NOT_FOUND_MESSAGE));
 
         updateExistingVehicle(existingVehicle, updatedVehicle);
         return VehicleRepository.save(existingVehicle);
@@ -42,6 +46,25 @@ public class VehicleServiceImpl implements VehicleService {
     @Override
     public void deleteVehicle(Long id) {
         VehicleRepository.deleteById(id);
+    }
+
+    @Override
+    @Transactional
+    public Vehicle addPhotoToVehicle(Long vehicleId, VehiclePhoto photo) {
+        Vehicle vehicle = vehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new ResourceNotFoundException(VEHICLE_NOT_FOUND_MESSAGE));
+
+        vehicle.setVehiclePhoto(photo);
+        return vehicleRepository.save(vehicle);
+    }
+
+    @Override
+    @Transactional
+    public VehiclePhoto getPhotoFromVehicle(Long vehicleId) {
+        Vehicle vehicle = vehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new ResourceNotFoundException(VEHICLE_NOT_FOUND_MESSAGE));
+
+        return vehicle.getVehiclePhoto();
     }
 
     private void updateExistingVehicle(Vehicle existingVehicle, Vehicle updatedVehicle) {


### PR DESCRIPTION
Added the ability to upload and retrieve photos for vehicles:
   - Introduced a new `VehiclePhoto` entity and associated repository, service, and DTO.
   - Updated `Vehicle` entity and `VehicleDto` to include photo references.
   - Implemented new API endpoints for managing vehicle photos, including storing and retrieving functionality.